### PR TITLE
Persist analysis state across sessions (closes #13)

### DIFF
--- a/backend/app/api/v1/routes_repo.py
+++ b/backend/app/api/v1/routes_repo.py
@@ -6,6 +6,8 @@ from app.core.config import settings
 from app.models import (
     AnalysisLoopRequest,
     AnalysisLoopResponse,
+    CachedStateRequest,
+    CachedStateResponse,
     GenerateReportRequest,
     GenerateReportResponse,
     IngestRepoRequest,
@@ -22,6 +24,7 @@ from app.services.analysis_snapshot_service import (
 )
 from app.services.ai_interpreter import interpret_architecture
 from app.services.report_generator import generate_html_report
+from app.services.analysis_state_store import save_state, load_state
 
 router = APIRouter(prefix="/repos", tags=["repos"])
 
@@ -94,7 +97,27 @@ async def run_repo_snapshot_loop(payload: AnalysisLoopRequest):
         initial_state=payload.analysis_state.model_dump(),
         max_steps=payload.max_steps,
     )
+    final_state = loop_result["final_state"]
+    save_state(
+        repo_id=final_state["repo_id"],
+        local_path=final_state["current_summary"]["local_path"],
+        final_state=final_state,
+        cache_dir=_resolve_cache_dir(),
+    )
     return AnalysisLoopResponse(**loop_result)
+
+
+@router.post("/state", response_model=CachedStateResponse)
+async def get_cached_state(payload: CachedStateRequest):
+    """Return persisted analysis state if it exists and matches current git HEAD."""
+    cached = load_state(
+        repo_id=payload.repo_id,
+        local_path=payload.local_path,
+        cache_dir=_resolve_cache_dir(),
+    )
+    if cached is None:
+        return CachedStateResponse(repo_id=payload.repo_id, found=False)
+    return CachedStateResponse(repo_id=payload.repo_id, found=True, final_state=cached)
 
 
 @router.post("/interpret", response_model=InterpretArchitectureResponse)
@@ -129,6 +152,13 @@ def _resolve_repo_base_dir() -> Path:
     if not repo_base_dir.is_absolute():
         return (Path.cwd() / repo_base_dir).resolve()
     return repo_base_dir.resolve()
+
+
+def _resolve_cache_dir() -> Path:
+    cache_dir = settings.ANALYSIS_CACHE_DIR
+    if not cache_dir.is_absolute():
+        return (Path.cwd() / cache_dir).resolve()
+    return cache_dir.resolve()
 
 
 def _resolve_reports_dir() -> Path:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,8 @@ from pathlib import Path
 class Settings(BaseSettings):
     # Base directory for cloned repositories
     REPO_BASE_DIR: Path = Path("./data/repos")
+    # Directory for persisted analysis state cache
+    ANALYSIS_CACHE_DIR: Path = Path("./data/analysis_cache")
 
     class Config:
         env_file = ".env"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,8 @@ from .repo_models import (
     AnalysisLoopResponse,
     AnalysisState,
     AnalysisStepTrace,
+    CachedStateRequest,
+    CachedStateResponse,
     DependencyEdge,
     GenerateReportRequest,
     GenerateReportResponse,

--- a/backend/app/models/repo_models.py
+++ b/backend/app/models/repo_models.py
@@ -74,7 +74,18 @@ class RepoAnalysisSnapshotResponse(BaseModel):
 
 class AnalysisLoopRequest(BaseModel):
     analysis_state: AnalysisState
-    max_steps: int = 5
+    max_steps: int = 15
+
+
+class CachedStateRequest(BaseModel):
+    repo_id: str
+    local_path: str
+
+
+class CachedStateResponse(BaseModel):
+    repo_id: str
+    found: bool
+    final_state: AnalysisState | None = None
 
 
 class AnalysisStepTrace(BaseModel):

--- a/backend/app/services/analysis_state_store.py
+++ b/backend/app/services/analysis_state_store.py
@@ -1,0 +1,71 @@
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+def save_state(repo_id: str, local_path: str, final_state: Dict, cache_dir: Path) -> None:
+    """Persist final_state to disk alongside the current git commit hash."""
+    commit_hash = _get_git_commit_hash(local_path)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = _cache_path(cache_dir, repo_id)
+    payload = {
+        "repo_id": repo_id,
+        "commit_hash": commit_hash,
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+        "final_state": final_state,
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    LOGGER.info("Saved analysis state for %s (commit %s)", repo_id, commit_hash or "unknown")
+
+
+def load_state(repo_id: str, local_path: str, cache_dir: Path) -> Optional[Dict]:
+    """
+    Load cached final_state if it exists and matches the current git HEAD.
+    Returns None if not found or stale.
+    """
+    cache_file = _cache_path(cache_dir, repo_id)
+    if not cache_file.exists():
+        return None
+
+    try:
+        payload = json.loads(cache_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.warning("Failed to read cache for %s: %s", repo_id, exc)
+        return None
+
+    current_hash = _get_git_commit_hash(local_path)
+    saved_hash = payload.get("commit_hash")
+
+    if current_hash and saved_hash and current_hash != saved_hash:
+        LOGGER.info(
+            "Cache stale for %s: saved at %s, current %s",
+            repo_id, saved_hash, current_hash,
+        )
+        return None
+
+    return payload.get("final_state")
+
+
+def _cache_path(cache_dir: Path, repo_id: str) -> Path:
+    safe_name = repo_id.replace("/", "__").replace("\\", "__")
+    return cache_dir / f"{safe_name}.json"
+
+
+def _get_git_commit_hash(local_path: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", local_path, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None


### PR DESCRIPTION
- analysis_state_store: new service that saves final_state as JSON keyed by repo_id, records git HEAD commit hash for staleness detection, and rejects cached state when the repo has new commits
- config: add ANALYSIS_CACHE_DIR setting (default data/analysis_cache/)
- routes_repo: auto-save state after /snapshot/run completes
- routes_repo: add POST /repos/state endpoint to retrieve cached state; returns found=false if cache is missing or stale
- models: add CachedStateRequest/CachedStateResponse, fix max_steps default from 5 to 15 in AnalysisLoopRequest