### PR TITLE
Analysis quality improvements, SSE streaming, and new language support

### DIFF
--- a/backend/app/api/v1/routes_repo.py
+++ b/backend/app/api/v1/routes_repo.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 from pathlib import Path
 import re
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
 from app.core.config import settings
 from app.models import (
     AnalysisLoopRequest,
@@ -112,6 +114,65 @@ async def run_repo_snapshot_loop(payload: AnalysisLoopRequest):
         cache_dir=_resolve_cache_dir(),
     )
     return AnalysisLoopResponse(**loop_result)
+
+
+@router.post("/snapshot/run/stream")
+async def stream_repo_snapshot_loop(payload: AnalysisLoopRequest):
+    """
+    Same as /snapshot/run but streams Server-Sent Events during the loop.
+    Each event is a JSON line prefixed with 'data: '.
+    Intermediate events: {"type": "progress", "file": "...", "step": n, "explored": n, "confidence": x}
+    Final event:        {"type": "done", ...AnalysisLoopResponse fields...}
+    """
+    repo_base_dir = _resolve_repo_base_dir()
+    local_path = payload.analysis_state.current_summary.local_path
+    requested_path = _resolve_local_path(local_path)
+
+    try:
+        requested_path.relative_to(repo_base_dir)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"local_path must be inside {repo_base_dir}")
+
+    if not requested_path.exists() or not requested_path.is_dir():
+        raise HTTPException(status_code=404, detail=f"Repository path not found: {requested_path}")
+
+    initial_state = payload.analysis_state.model_dump()
+    event_loop = asyncio.get_event_loop()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def on_progress(event: dict):
+        event_loop.call_soon_threadsafe(queue.put_nowait, event)
+
+    async def generate():
+        task = asyncio.create_task(
+            asyncio.to_thread(run_agentic_analysis_loop, initial_state, payload.max_steps, on_progress)
+        )
+        # Drain progress events while the loop runs.
+        while not task.done():
+            try:
+                event = await asyncio.wait_for(asyncio.shield(queue.get()), timeout=0.2)
+                yield f"data: {json.dumps(event)}\n\n"
+            except asyncio.TimeoutError:
+                continue
+
+        # Drain any remaining events after the task finishes.
+        while not queue.empty():
+            event = queue.get_nowait()
+            yield f"data: {json.dumps(event)}\n\n"
+
+        loop_result = task.result()
+        final_state = loop_result["final_state"]
+        save_state(
+            repo_id=final_state["repo_id"],
+            local_path=final_state["current_summary"]["local_path"],
+            final_state=final_state,
+            cache_dir=_resolve_cache_dir(),
+        )
+        done_event = {**AnalysisLoopResponse(**loop_result).model_dump(), "type": "done"}
+        yield f"data: {json.dumps(done_event)}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream",
+                              headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
 
 
 @router.post("/state", response_model=CachedStateResponse)

--- a/backend/app/services/agentic_analysis_service.py
+++ b/backend/app/services/agentic_analysis_service.py
@@ -9,7 +9,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import ollama
 
@@ -169,7 +169,11 @@ _TOOLS = [
 ]
 
 
-def run_agentic_analysis_loop(initial_state: Dict, max_steps: int = 15) -> Dict:
+def run_agentic_analysis_loop(
+    initial_state: Dict,
+    max_steps: int = 15,
+    on_progress: Optional[Callable[[Dict], None]] = None,
+) -> Dict:
     """
     Agentic replacement for run_analysis_loop.
 
@@ -221,6 +225,9 @@ def run_agentic_analysis_loop(initial_state: Dict, max_steps: int = 15) -> Dict:
                 })
                 new_file = _newly_explored_file(previous_explored, state["explored_files"])
                 step_trace.append(_trace_entry(step, new_file, state))
+                if on_progress and new_file:
+                    on_progress({"type": "progress", "file": new_file, "step": step,
+                                 "explored": len(state["explored_files"]), "confidence": round(state["confidence"], 2)})
                 consecutive_no_file_steps = 0
                 continue
             else:
@@ -271,6 +278,9 @@ def run_agentic_analysis_loop(initial_state: Dict, max_steps: int = 15) -> Dict:
                     explored_this_step = new_file
                     file_explored_this_step = True
                     previous_explored = list(state["explored_files"])
+                    if on_progress:
+                        on_progress({"type": "progress", "file": new_file, "step": step,
+                                     "explored": len(state["explored_files"]), "confidence": round(state["confidence"], 2)})
             elif side_effect == "stop":
                 stop_this_step = True
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import {
   ingestRepo,
   getSnapshot,
-  runLoop,
+  runLoopStream,
   interpretArchitecture,
   generateReport,
   fetchReportHtml,
@@ -60,6 +60,7 @@ export default function App() {
   const [reportHtml, setReportHtml] = useState<string | null>(null);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [depthIdx, setDepthIdx]     = useState(1); // default: Standard
+  const [liveFile, setLiveFile]     = useState<string | null>(null);
 
   function updateStep(id: string, patch: Partial<Step>) {
     setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
@@ -87,9 +88,15 @@ export default function App() {
         detail: `${snapshot.repo_summary.file_count} files · ${snapshot.repo_summary.languages.join(", ")}`,
       });
 
-      // 3. Analysis loop
+      // 3. Analysis loop (streaming)
       updateStep("loop", { status: "running" });
-      const loopResult = await runLoop(snapshot.analysis_state, DEPTH_OPTIONS[depthIdx].steps);
+      setLiveFile(null);
+      const loopResult = await runLoopStream(
+        snapshot.analysis_state,
+        DEPTH_OPTIONS[depthIdx].steps,
+        (evt) => setLiveFile(`${evt.file} · ${evt.explored} files · ${(evt.confidence * 100).toFixed(0)}%`),
+      );
+      setLiveFile(null);
       const finalState: AnalysisState = loopResult.final_state;
       updateStep("loop", {
         status: "done",
@@ -123,6 +130,7 @@ export default function App() {
       const html = await fetchReportHtml(reportResp.report_path);
       setReportHtml(html);
     } catch (err: unknown) {
+      setLiveFile(null);
       const msg = err instanceof Error ? err.message : String(err);
       setGlobalError(msg);
       setSteps((prev) =>
@@ -184,7 +192,9 @@ export default function App() {
                 <span className="step-icon">{ICONS[step.status]}</span>
                 <span className="step-label">{step.label}</span>
                 {isLoopRunning
-                  ? <ElapsedTimer prefix="Running… " />
+                  ? liveFile
+                    ? <span className="step-detail">{liveFile}</span>
+                    : <ElapsedTimer prefix="Waiting for model… " />
                   : step.detail && <span className="step-detail">{step.detail}</span>
                 }
               </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -101,6 +101,49 @@ export async function runLoop(state: AnalysisState, maxSteps = 15): Promise<Loop
   return res.json();
 }
 
+export interface ProgressEvent {
+  type: "progress";
+  file: string;
+  step: number;
+  explored: number;
+  confidence: number;
+}
+
+export async function runLoopStream(
+  state: AnalysisState,
+  maxSteps: number,
+  onProgress: (event: ProgressEvent) => void,
+): Promise<LoopResponse> {
+  const res = await fetch(`${BASE}/snapshot/run/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ analysis_state: state, max_steps: maxSteps }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(err.detail ?? res.statusText);
+  }
+
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const payload = JSON.parse(line.slice(6));
+      if (payload.type === "done") return payload as LoopResponse;
+      if (payload.type === "progress") onProgress(payload as ProgressEvent);
+    }
+  }
+  throw new Error("Stream ended without a done event");
+}
+
 export async function interpretArchitecture(finalState: AnalysisState): Promise<InterpretResponse> {
   const res = await fetch(`${BASE}/interpret`, {
     method: "POST",


### PR DESCRIPTION
## Summary

- **#46** — Inject directory tree (top 2 levels) into agentic loop system prompt so the model understands repo structure before choosing files to explore
- **#50** — Guard against oversized repos: query GitHub API before cloning, reject with clear error if size exceeds `REPO_MAX_SIZE_MB` (default 500MB)
- **#48** — Add Rust (`use`, `mod`, `extern crate`) and C++ (`#include`) import extraction, wired into `_extract_imports_for_file()`
- **#47** — Add Quick / Standard / Deep depth selector to UI (10 / 20 / 30 steps)
- **#44** — Stream analysis progress via SSE: new `/snapshot/run/stream` endpoint emits per-file progress events; frontend shows live file name + explored count + confidence during the loop step
