### PR TITLE
Improve exploration breadth and dependency-graph fidelity

### DIFF
--- a/backend/app/api/v1/routes_repo.py
+++ b/backend/app/api/v1/routes_repo.py
@@ -29,7 +29,12 @@ from app.services.analysis_snapshot_service import (
 from app.services.agentic_analysis_service import run_agentic_analysis_loop
 from app.services.ai_interpreter import interpret_architecture
 from app.services.report_generator import generate_html_report
-from app.services.analysis_state_store import save_state, load_state, list_history
+from app.services.analysis_state_store import (
+    delete_state,
+    list_history,
+    load_state,
+    save_state,
+)
 
 router = APIRouter(prefix="/repos", tags=["repos"])
 
@@ -104,6 +109,12 @@ async def run_repo_snapshot_loop(payload: AnalysisLoopRequest):
             detail=f"Repository path not found: {requested_path}",
         )
 
+    if payload.force_refresh:
+        delete_state(
+            repo_id=payload.analysis_state.repo_id,
+            cache_dir=_resolve_cache_dir(),
+        )
+
     initial_state = payload.analysis_state.model_dump()
     loop_result = await asyncio.to_thread(
         run_agentic_analysis_loop, initial_state, payload.max_steps
@@ -137,6 +148,12 @@ async def stream_repo_snapshot_loop(payload: AnalysisLoopRequest):
 
     if not requested_path.exists() or not requested_path.is_dir():
         raise HTTPException(status_code=404, detail=f"Repository path not found: {requested_path}")
+
+    if payload.force_refresh:
+        delete_state(
+            repo_id=payload.analysis_state.repo_id,
+            cache_dir=_resolve_cache_dir(),
+        )
 
     initial_state = payload.analysis_state.model_dump()
     event_loop = asyncio.get_event_loop()

--- a/backend/app/models/repo_models.py
+++ b/backend/app/models/repo_models.py
@@ -76,6 +76,7 @@ class RepoAnalysisSnapshotResponse(BaseModel):
 class AnalysisLoopRequest(BaseModel):
     analysis_state: AnalysisState
     max_steps: int = 15
+    force_refresh: bool = False
 
 
 class CachedStateRequest(BaseModel):

--- a/backend/app/services/agentic_analysis_service.py
+++ b/backend/app/services/agentic_analysis_service.py
@@ -5,6 +5,7 @@ returns the same dict shape so the route needs no changes to its response handli
 """
 import json
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass
@@ -202,6 +203,12 @@ def run_agentic_analysis_loop(
     messages: List = [_build_system_message(state)]
     step_trace: List[Dict] = []
     consecutive_no_file_steps = 0
+    # Total non-file-reading steps (search, mark_insight, nudge turns).
+    # Capped at max_steps // 3 so non-exploring actions can't silently
+    # consume the whole step budget. When the cap is hit, the loop
+    # force-reads the next unexplored file just like the consecutive guard.
+    total_non_file_steps = 0
+    max_non_file_steps = max_steps // 3
     # Max recent messages to keep (excluding the system prompt at index 0).
     # Prevents context from growing unboundedly and slowing down Ollama calls.
     _MAX_HISTORY = 12
@@ -236,6 +243,23 @@ def run_agentic_analysis_loop(
                 state["stop_reason"] = "All candidate files have been explored."
                 break
 
+        # Non-file budget guard: even if non-file steps aren't consecutive,
+        # too many cumulatively still wastes the run. Force-read once the
+        # cap is exceeded.
+        if total_non_file_steps >= max_non_file_steps:
+            forced = _next_unexplored(state)
+            if forced:
+                LOGGER.info(
+                    "Step %d: force-reading '%s' — non-file budget (%d/%d) exhausted.",
+                    step, forced, total_non_file_steps, max_non_file_steps,
+                )
+                result, _ = _tool_read_file(state, forced)
+                messages.append({"role": "tool", "content": result, "tool_use_id": "force_read"})
+                step_trace.append(_trace_entry(step, "force_read_budget", state))
+                total_non_file_steps = 0  # reset after force-read
+                consecutive_no_file_steps = 0
+                continue
+
         # Trim history: always keep system prompt (index 0) + last _MAX_HISTORY messages.
         if len(messages) > _MAX_HISTORY + 1:
             messages = [messages[0]] + messages[-_MAX_HISTORY:]
@@ -256,6 +280,7 @@ def run_agentic_analysis_loop(
             messages.append(_nudge_message(state))
             step_trace.append(_trace_entry(step, None, state))
             consecutive_no_file_steps += 1
+            total_non_file_steps += 1
             continue
 
         explored_this_step: Optional[str] = None
@@ -290,6 +315,7 @@ def run_agentic_analysis_loop(
             # Tool calls made but no new file explored — nudge and count.
             messages.append(_nudge_message(state))
             consecutive_no_file_steps += 1
+            total_non_file_steps += 1
 
         step_trace.append(_trace_entry(step, explored_this_step, state))
 
@@ -297,6 +323,10 @@ def run_agentic_analysis_loop(
             break
 
     state["dependency_graph_summary"] = _compute_dependency_graph_summary(state)
+    # Persist for diagnostic visibility in the cache. Pydantic's
+    # AnalysisState ignores extras, so this survives JSON serialization to
+    # disk but is stripped from the API response.
+    state["total_non_file_steps"] = total_non_file_steps
     # Keep candidate_files fresh so AnalysisState validation passes.
     _refresh_candidates_for_signal(state, limit=8)
 
@@ -362,6 +392,19 @@ def _build_system_message(state: Dict) -> Dict:
     explored_str = ", ".join(explored) if explored else "none yet"
     unknowns_str = "; ".join(unknowns) if unknowns else "none"
 
+    # Compute visited vs unvisited directory sets so the agent doesn't have
+    # to mentally parse "Already explored" to figure out where it hasn't been.
+    explored_files = state.get("explored_files", [])
+    all_files = state.get("_cached_files", [])
+    explored_dirs = set(
+        os.path.dirname(f) for f in explored_files if os.path.dirname(f)
+    )
+    all_dirs = set(
+        os.path.dirname(f) for f in all_files if os.path.dirname(f)
+    )
+    unvisited_dirs = sorted(all_dirs - explored_dirs)
+    visited_dirs = sorted(explored_dirs)
+
     min_files = min(15, max(6, int(summary["file_count"] * 0.65)))
 
     dir_tree = _build_dir_tree(cached_files)
@@ -375,12 +418,19 @@ def _build_system_message(state: Dict) -> Dict:
         f"Already explored: {explored_str}\n"
         f"Open questions: {unknowns_str}\n\n"
         f"Suggested starting candidates:\n{candidate_lines}\n\n"
+        f"Visited directories: {', '.join(visited_dirs) if visited_dirs else 'none yet'}\n"
+        f"NOT YET VISITED (prioritize these): {', '.join(unvisited_dirs) if unvisited_dirs else 'all covered'}\n\n"
         f"RULES (follow strictly):\n"
         f"1. You MUST call read_file or follow_import at least {min_files} times before "
         f"calling stop_analysis. Do not stop early.\n"
         f"2. After reading a file, always follow at least one of its imports with follow_import "
         f"to trace the dependency chain.\n"
-        f"3. Cover different directories and roles — not just one cluster of files.\n"
+        f"3. Actively spread across directories — after every 2-3 files you "
+        f"read in the same directory, deliberately pick a file from a directory "
+        f"you have NOT yet visited. Check the directory tree and identify which "
+        f"top-level folders have zero explored files, then prioritize those. "
+        f"A good analysis covers components/, utils/, hooks/, services/, api/, "
+        f"types/ — not just the entry point chain.\n"
         f"4. Use mark_architecture_insight to record what you learn about entry points, "
         f"components, and patterns.\n"
         f"5. Only call stop_analysis after you have read at least {min_files} files AND "
@@ -418,8 +468,10 @@ def _build_language_guidance(languages: List[str], files: List[str], repo_path: 
             )
         if "vite.config.ts" in file_set or "vite.config.js" in file_set:
             js_lines.append(
-                "Vite detected — prioritize src/main.tsx or src/main.ts as "
-                "entry point, then src/App.tsx."
+                "Vite detected — start at src/main.tsx or src/main.ts to "
+                "understand the entry point, then SPREAD OUT: explore one "
+                "file from each major directory (components/, utils/, hooks/, "
+                "api/, types/) before going deeper into any single chain."
             )
         pkg_entry = _read_package_json_entry(repo_path)
         if pkg_entry:
@@ -427,7 +479,9 @@ def _build_language_guidance(languages: List[str], files: List[str], repo_path: 
         js_lines.append(
             "General JS/TS: prioritize index.ts, App.tsx, main.ts, router "
             "files, and any file named index.ts inside a directory (barrel "
-            "files reveal the public API of that module)."
+            "files reveal the public API of that module). "
+            "Do not follow a single import chain all the way down — read one "
+            "file per directory before revisiting any directory."
         )
         blocks.append("\n".join(js_lines))
 
@@ -532,7 +586,13 @@ def _tool_read_file(state: Dict, file_path: str) -> Tuple[str, Optional[str]]:
                 None,
             )
 
-    candidate_is_import_target = file_path in _resolved_import_targets(state)
+    repo_path = Path(state["current_summary"]["local_path"]).resolve()
+    candidate_is_import_target = file_path in _resolved_import_targets(
+        state,
+        repo_path=repo_path,
+        package_roots=state.get("package_roots", []),
+        scanned_files=set(state.get("_cached_files", [])),
+    )
     inspected = _inspect_file(state, file_path)
     if inspected is None:
         return (
@@ -781,18 +841,30 @@ def _file_preview(path: Path) -> str:
 def _next_unexplored(state: Dict) -> Optional[str]:
     """
     Return the next unexplored file, or None if all files have been explored.
-    Checks candidate_files first (scored/prioritised), then falls back to
-    scanning ALL repo files so nothing is missed.
+
+    Selection order:
+      1. Prioritised candidates from a directory not yet visited (breadth-first
+         pressure — counteracts the depth-first chain-following tendency).
+      2. Any prioritised candidate.
+      3. Any file in the repo.
     """
     explored = set(state.get("explored_files", []))
+    explored_dirs = set(os.path.dirname(f) for f in explored)
 
-    # 1. Prioritised candidates first (skip noise files).
+    # First pass: candidates in unvisited directories.
+    for c in state.get("candidate_files", []):
+        fp = c["file_path"]
+        if fp not in explored and not _is_noise_file(fp):
+            if os.path.dirname(fp) not in explored_dirs:
+                return fp
+
+    # Second pass: any unvisited candidate (visited directory is acceptable here).
     for c in state.get("candidate_files", []):
         fp = c["file_path"]
         if fp not in explored and not _is_noise_file(fp):
             return fp
 
-    # 2. Fall back to every file in the repo (skip noise files).
+    # Final fallback: every file in the repo.
     for f in state.get("_cached_files", []):
         if f not in explored and not _is_noise_file(f):
             return f
@@ -803,6 +875,11 @@ def _nudge_message(state: Dict) -> Dict:
     """
     Injected as a user turn when the model goes silent or makes no file-exploring call.
     Lists unexplored files explicitly so the model has a clear next action.
+
+    Prefers files from directories the agent has not yet visited. Same-chain
+    import targets are only surfaced when no unvisited-directory candidates
+    are available — this counteracts the agent's tendency to follow a single
+    import chain depth-first.
     """
     explored = set(state.get("explored_files", []))
     candidates = [
@@ -810,12 +887,40 @@ def _nudge_message(state: Dict) -> Dict:
         if c["file_path"] not in explored and not _is_noise_file(c["file_path"])
     ]
     # Also surface any files reachable via imports that haven't been read yet.
+    # Pass repo context when available so resolved paths carry file extensions
+    # — degrades to naive arithmetic if state lacks current_summary (e.g. tests).
+    local_path = state.get("current_summary", {}).get("local_path")
+    repo_path = Path(local_path).resolve() if local_path else None
     import_targets = [
-        t for t in _resolved_import_targets(state)
+        t for t in _resolved_import_targets(
+            state,
+            repo_path=repo_path,
+            package_roots=state.get("package_roots", []),
+            scanned_files=set(state.get("_cached_files", [])) if repo_path else None,
+        )
         if t not in explored and not _is_noise_file(t)
     ]
-    unexplored = candidates + [t for t in import_targets if t not in candidates]
 
+    explored_dirs = set(
+        os.path.dirname(f) for f in state.get("explored_files", [])
+    )
+    unvisited_candidates = [
+        c for c in candidates
+        if os.path.dirname(c) not in explored_dirs
+    ]
+
+    if unvisited_candidates:
+        file_list = "\n".join(f"  - {f}" for f in unvisited_candidates[:8])
+        return {
+            "role": "user",
+            "content": (
+                f"You have stayed in the same directory too long. These files are "
+                f"from directories you have not yet explored — pick one and call "
+                f"read_file:\n{file_list}"
+            ),
+        }
+
+    unexplored = candidates + [t for t in import_targets if t not in candidates]
     if unexplored:
         file_list = "\n".join(f"  - {f}" for f in unexplored[:8])
         return {

--- a/backend/app/services/analysis_snapshot_service.py
+++ b/backend/app/services/analysis_snapshot_service.py
@@ -638,7 +638,12 @@ def _refresh_candidates_for_signal(state: Dict, limit: int) -> None:
     file_languages: Dict[str, str] = scan_result["file_languages"]
     explored = set(state["explored_files"])
 
-    known_targets = _resolved_import_targets(state)
+    known_targets = _resolved_import_targets(
+        state,
+        repo_path=repo_path,
+        package_roots=state.get("package_roots", []),
+        scanned_files=set(files),
+    )
     scored: List[Tuple[Tuple[int, str], Dict]] = []
     for file_path in files:
         if file_path in explored:
@@ -674,16 +679,49 @@ def _refresh_candidates_for_signal(state: Dict, limit: int) -> None:
     state["candidate_files"] = candidates
 
 
-def _resolved_import_targets(state: Dict) -> Set[str]:
-    """Return the set of internal file paths that explored files import."""
-    targets: Set[str] = set()
+def _resolved_import_targets(
+    state: Dict,
+    repo_path: Path | None = None,
+    package_roots: List[str] | None = None,
+    scanned_files: Set[str] | None = None,
+) -> Counter:
+    """
+    Return a Counter mapping internal file paths → number of explored files
+    that import that path.
+
+    When ``repo_path`` and ``scanned_files`` are provided, uses the full
+    ``_resolve_internal_import`` — which resolves relative imports to actual
+    files with extensions and handles Python absolute imports via package
+    roots. This matches what ``_compute_dependency_graph_summary`` produces.
+
+    Without repo context, falls back to naive POSIX-path arithmetic on
+    relative-only imports. The fallback strips file extensions (e.g.
+    ``./formFieldsSource`` → ``datasources/formFieldsSource``), so callers
+    that compare against real ``scanned_files`` paths should always pass
+    repo context — otherwise the comparison never matches.
+
+    The Counter shape lets callers reward files imported by multiple
+    explored files higher than files imported by one.
+    """
+    targets: Counter = Counter()
+    package_root_paths = [Path(r) for r in (package_roots or [])]
     for edge in state.get("dependency_edges", []):
         source = edge["source"]
-        source_dir = posixpath.dirname(source)
         for imp in edge.get("imports", []):
-            if imp.startswith(("./", "../")):
-                resolved = posixpath.normpath(posixpath.join(source_dir, imp))
-                targets.add(resolved)
+            if repo_path is not None and scanned_files is not None:
+                resolved = _resolve_internal_import(
+                    repo_path=repo_path,
+                    source_file=source,
+                    import_specifier=imp,
+                    package_roots=package_root_paths,
+                    scanned_files=scanned_files,
+                )
+                if resolved:
+                    targets[resolved] += 1
+            elif imp.startswith(("./", "../")):
+                source_dir = posixpath.dirname(source)
+                naive = posixpath.normpath(posixpath.join(source_dir, imp))
+                targets[naive] += 1
     return targets
 
 
@@ -691,7 +729,7 @@ def _candidate_signal_score(
     state: Dict,
     file_path: str,
     file_languages: Dict[str, str],
-    known_targets: Set[str] | None = None,
+    known_targets: Counter | None = None,
 ) -> Tuple[int, List[str]]:
     name = Path(file_path).name
     top_level_dir = Path(file_path).parts[0] if Path(file_path).parts else ""
@@ -728,6 +766,17 @@ def _candidate_signal_score(
         score += 3
         reasons.append("new directory context")
 
+    # Unvisited-directory bonus on top of "new directory context".
+    # Combined: +7 for a candidate in a directory the agent hasn't entered yet,
+    # which outweighs the +3 known-import-target chain-following bias below.
+    explored_dirs = set(
+        str(Path(f).parent) for f in state.get("explored_files", [])
+    )
+    file_dir = str(Path(file_path).parent)
+    if file_dir not in explored_dirs:
+        score += 4
+        reasons.append("unvisited directory")
+
     if role_hint not in inspected_roles:
         score += 2
         reasons.append(f"new file role ({role_hint})")
@@ -748,11 +797,15 @@ def _candidate_signal_score(
     # Boost files that are known import targets from already-explored files.
     # These are high-value: exploring them reveals their own imports and
     # completes the dependency graph rather than hitting dead-end files.
+    # Bonus scales with in-degree (how many explored files import this one),
+    # capped at +9 so even a heavily-imported leaf doesn't dominate breadth.
     if known_targets is None:
         known_targets = _resolved_import_targets(state)
     if file_path in known_targets:
-        score += 5
-        reasons.append("known import target from explored files")
+        import_count = known_targets[file_path]
+        bonus = min(import_count * 3, 9)
+        score += bonus
+        reasons.append(f"known import target from {import_count} explored file(s)")
 
     if role_hint == "test":
         score -= 2

--- a/backend/app/services/analysis_state_store.py
+++ b/backend/app/services/analysis_state_store.py
@@ -51,6 +51,20 @@ def load_state(repo_id: str, local_path: str, cache_dir: Path) -> Optional[Dict]
     return payload.get("final_state")
 
 
+def delete_state(repo_id: str, cache_dir: Path) -> None:
+    """
+    Remove the cache file for a repo_id, if present. Idempotent — missing
+    file is not an error. Use to force a fresh analysis on the next run
+    regardless of git HEAD or staleness state.
+    """
+    cache_file = _cache_path(cache_dir, repo_id)
+    try:
+        cache_file.unlink(missing_ok=True)
+        LOGGER.info("Deleted cached state for %s", repo_id)
+    except OSError as exc:
+        LOGGER.warning("Failed to delete cache for %s: %s", repo_id, exc)
+
+
 def list_history(cache_dir: Path) -> list:
     """
     Return metadata for all cached analyses, sorted newest first.

--- a/backend/app/services/repo_metadata.py
+++ b/backend/app/services/repo_metadata.py
@@ -22,6 +22,26 @@ KNOWN_TOP_LEVEL_DIRS = {
     "app",
     "tests",
     "docs",
+    # Common functional/layered directory names in real-world JS/TS and Python
+    # projects. Previously these earned no domain-signal boost despite being
+    # standard architectural layers.
+    "utils",
+    "hooks",
+    "services",
+    "api",
+    "types",
+    "components",
+    "datasources",
+    "lib",
+    "helpers",
+    "middleware",
+    "store",
+    "context",
+    "features",
+    "modules",
+    "controllers",
+    "repositories",
+    "domain",
 }
 
 

--- a/backend/tests/test_core_services.py
+++ b/backend/tests/test_core_services.py
@@ -4,11 +4,13 @@ Covers: import extraction, internal import resolution, noise file filtering,
 and dependency graph computation.
 """
 import tempfile
+from collections import Counter
 from pathlib import Path
 
 import pytest
 
 from app.services.analysis_snapshot_service import (
+    _candidate_signal_score,
     _compute_dependency_graph_summary,
     _extract_imports_for_file,
     _extract_java_imports,
@@ -16,10 +18,13 @@ from app.services.analysis_snapshot_service import (
     _extract_javascript_imports,
     _extract_python_imports,
     _resolve_internal_import,
+    _resolved_import_targets,
 )
 from app.services.agentic_analysis_service import (
     _build_language_guidance,
     _is_noise_file,
+    _next_unexplored,
+    _nudge_message,
 )
 from app.services import report_generator
 from app.services.report_generator import generate_html_report
@@ -29,6 +34,11 @@ from app.services.ai_interpreter import (
     _build_prompt,
     _validate_interpretation,
     interpret_architecture,
+)
+from app.services.analysis_state_store import (
+    delete_state,
+    load_state,
+    save_state,
 )
 
 
@@ -526,6 +536,56 @@ class TestResolveInternalImport:
         )
         assert result is None
 
+    # ---- _resolved_import_targets ----
+
+    def test_resolved_import_targets_uses_real_resolver_with_repo_context(self):
+        # The bug we fixed: ./formFieldsSource was being stored as
+        # "datasources/formFieldsSource" (no extension), which never matched
+        # the actual file "datasources/formFieldsSource.ts" in scanned_files.
+        # With repo context, the resolver now returns the correct path.
+        repo = self._make_repo({
+            "datasources/index.ts": "",
+            "datasources/formFieldsSource.ts": "",
+        })
+        state = {
+            "dependency_edges": [
+                {
+                    "source": "datasources/index.ts",
+                    "imports": ["./formFieldsSource"],
+                }
+            ],
+        }
+        scanned = {"datasources/index.ts", "datasources/formFieldsSource.ts"}
+
+        result = _resolved_import_targets(
+            state,
+            repo_path=repo,
+            package_roots=[],
+            scanned_files=scanned,
+        )
+
+        assert "datasources/formFieldsSource.ts" in result
+        # The naive extension-less path must NOT be in the result.
+        assert "datasources/formFieldsSource" not in result
+
+    def test_resolved_import_targets_falls_back_without_repo_context(self):
+        # Backward compat: callers that don't pass repo context still get the
+        # naive arithmetic. The dead-code call sites still rely on this.
+        state = {
+            "dependency_edges": [
+                {
+                    "source": "datasources/index.ts",
+                    "imports": ["./formFieldsSource"],
+                }
+            ],
+        }
+
+        result = _resolved_import_targets(state)
+
+        # Naive arithmetic preserves the legacy (broken) behavior — confirms
+        # the fallback path is exercised when no repo context is passed.
+        assert "datasources/formFieldsSource" in result
+
 
 # ---------------------------------------------------------------------------
 # _compute_dependency_graph_summary
@@ -615,6 +675,8 @@ class TestBuildLanguageGuidance:
             assert "General JS/TS" in out
             assert "Next.js" not in out
             assert "Vite" not in out
+            # Breadth-first instruction appended to the general JS/TS block.
+            assert "read one file per directory" in out
 
     def test_typescript_picks_up_next_config(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -631,6 +693,8 @@ class TestBuildLanguageGuidance:
             )
             assert "Vite detected" in out
             assert "src/main.tsx" in out
+            # Breadth-first instruction in the Vite block.
+            assert "SPREAD OUT" in out
 
     def test_reads_package_json_main_field(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -849,3 +913,290 @@ class TestInterpreterPromptAndFallback:
             assert len(result["key_dependencies"]) >= 1
             for dep in result["key_dependencies"]:
                 assert dep["reason"] == "high-import-count dependency (deterministic fallback)"
+
+
+# ---------------------------------------------------------------------------
+# Directory-aware exploration: _next_unexplored and _nudge_message
+# ---------------------------------------------------------------------------
+
+class TestNudgeAndNextUnexplored:
+    def test_next_unexplored_prefers_unvisited_directory(self):
+        # Same-dir candidate is listed first, but the unvisited-dir candidate
+        # should still win because of the first-pass dir-aware preference.
+        state = {
+            "explored_files": ["src/components/Button.tsx"],
+            "candidate_files": [
+                {"file_path": "src/components/Card.tsx", "reason": "same dir"},
+                {"file_path": "src/utils/format.ts",     "reason": "unvisited"},
+            ],
+            "_cached_files": [
+                "src/components/Button.tsx",
+                "src/components/Card.tsx",
+                "src/utils/format.ts",
+            ],
+        }
+        assert _next_unexplored(state) == "src/utils/format.ts"
+
+    def test_next_unexplored_falls_back_when_all_dirs_visited(self):
+        # Only candidate lives in the already-visited directory — first pass
+        # finds nothing, second pass returns it rather than going to fallback.
+        state = {
+            "explored_files": ["src/components/Button.tsx"],
+            "candidate_files": [
+                {"file_path": "src/components/Card.tsx", "reason": "same dir"},
+            ],
+            "_cached_files": [
+                "src/components/Button.tsx",
+                "src/components/Card.tsx",
+            ],
+        }
+        assert _next_unexplored(state) == "src/components/Card.tsx"
+
+    def test_nudge_prefers_unvisited_directory_candidates(self):
+        state = {
+            "explored_files": ["src/components/Button.tsx"],
+            "candidate_files": [
+                {"file_path": "src/components/Card.tsx", "reason": "same dir"},
+                {"file_path": "src/utils/format.ts",     "reason": "unvisited"},
+            ],
+            "dependency_edges": [],
+        }
+        result = _nudge_message(state)
+        content = result["content"]
+        # New "stayed in same directory" wording is used.
+        assert "stayed in the same directory" in content
+        # Unvisited-dir candidate is surfaced.
+        assert "src/utils/format.ts" in content
+        # Same-dir candidate is NOT listed when an unvisited one is available.
+        assert "src/components/Card.tsx" not in content
+
+    def test_nudge_falls_back_to_combined_list_when_no_unvisited_dirs(self):
+        # All candidates live in the already-visited directory and there are no
+        # import targets to surface — we expect the original generic wording.
+        state = {
+            "explored_files": ["src/components/Button.tsx"],
+            "candidate_files": [
+                {"file_path": "src/components/Card.tsx", "reason": "same dir"},
+            ],
+            "dependency_edges": [],
+        }
+        result = _nudge_message(state)
+        content = result["content"]
+        assert "stayed in the same directory" not in content
+        # Falls back to the original generic prompt …
+        assert "have not yet read these files" in content
+        # … which surfaces the same-dir candidate as a last resort.
+        assert "src/components/Card.tsx" in content
+
+
+# ---------------------------------------------------------------------------
+# analysis_state_store — delete_state and force_refresh semantics
+# ---------------------------------------------------------------------------
+
+class TestDeleteStateAndForceRefresh:
+    def test_delete_state_removes_existing_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cache_dir = tmp_path / "cache"
+            save_state(
+                repo_id="myrepo",
+                local_path=str(tmp_path),
+                final_state={"k": "v"},
+                cache_dir=cache_dir,
+            )
+            cache_file = cache_dir / "myrepo.json"
+            assert cache_file.exists()
+
+            delete_state(repo_id="myrepo", cache_dir=cache_dir)
+            assert not cache_file.exists()
+
+    def test_delete_state_missing_file_is_noop(self):
+        # Should not raise, and should not create the file.
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_dir = Path(tmp) / "cache"
+            cache_dir.mkdir()
+            delete_state(repo_id="never-existed", cache_dir=cache_dir)
+            assert not (cache_dir / "never-existed.json").exists()
+
+    def test_load_returns_none_after_delete_even_with_matching_hash(self, monkeypatch):
+        # Pin the git hash so load_state's staleness check would normally
+        # succeed — this isolates the delete behavior from staleness logic.
+        monkeypatch.setattr(
+            "app.services.analysis_state_store._get_git_commit_hash",
+            lambda local_path: "abc123",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cache_dir = tmp_path / "cache"
+            save_state(
+                repo_id="myrepo",
+                local_path=str(tmp_path),
+                final_state={"k": "v"},
+                cache_dir=cache_dir,
+            )
+
+            # Sanity: with the git hash unchanged, load returns the cached state.
+            assert load_state("myrepo", str(tmp_path), cache_dir) == {"k": "v"}
+
+            delete_state(repo_id="myrepo", cache_dir=cache_dir)
+
+            # After delete, load returns None — even though git HEAD didn't move.
+            assert load_state("myrepo", str(tmp_path), cache_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# _candidate_signal_score: unvisited-directory bonus and reduced chain pull
+# ---------------------------------------------------------------------------
+
+class TestCandidateSignalScore:
+    @staticmethod
+    def _state_with_explored(explored_files):
+        """Minimal state with explored_files mirrored as inspected_facts."""
+        return {
+            "explored_files": list(explored_files),
+            "inspected_facts": [
+                {
+                    "file_path": fp,
+                    "language": "python",
+                    "role_hint": "module",
+                    "directory": str(Path(fp).parent),
+                    "line_count_bucket": "small",
+                    "imported_modules": [],
+                }
+                for fp in explored_files
+            ],
+            "unknowns": [],
+            "current_summary": {
+                "top_level_dirs": ["src"],
+                "entry_points": [],
+                "languages": ["python"],
+            },
+            "dependency_edges": [],
+        }
+
+    def test_unvisited_directory_reason_fires(self):
+        state = self._state_with_explored(["src/foo.py"])
+        file_languages = {"src/foo.py": "python", "src/utils/bar.py": "python"}
+
+        score, reasons = _candidate_signal_score(
+            state, "src/utils/bar.py", file_languages, known_targets=set()
+        )
+
+        assert "unvisited directory" in reasons
+        # The pre-existing per-fact "new directory context" still fires alongside.
+        assert "new directory context" in reasons
+
+    def test_unvisited_directory_reason_does_not_fire_in_visited_dir(self):
+        # The candidate lives in the same directory the agent has already been in.
+        state = self._state_with_explored(["src/utils/foo.py"])
+        file_languages = {"src/utils/foo.py": "python", "src/utils/bar.py": "python"}
+
+        score, reasons = _candidate_signal_score(
+            state, "src/utils/bar.py", file_languages, known_targets=set()
+        )
+
+        assert "unvisited directory" not in reasons
+
+    def test_unvisited_directory_score_delta(self):
+        # Score the same candidate against two states that differ only in
+        # whether its parent directory has been explored. The score delta
+        # equals the +3 (new directory context) + +4 (unvisited directory)
+        # contributions for a total of +7.
+        file_languages = {
+            "src/foo.py": "python",
+            "src/utils/bar.py": "python",
+            "src/utils/baz.py": "python",
+        }
+        state_unvisited = self._state_with_explored(["src/foo.py"])
+        state_visited = self._state_with_explored(["src/foo.py", "src/utils/baz.py"])
+
+        score_unvisited, _ = _candidate_signal_score(
+            state_unvisited, "src/utils/bar.py", file_languages, known_targets=set()
+        )
+        score_visited, _ = _candidate_signal_score(
+            state_visited, "src/utils/bar.py", file_languages, known_targets=set()
+        )
+
+        assert score_unvisited - score_visited == 7
+
+    def test_known_import_target_bonus_three_for_single_importer(self):
+        # In-degree of 1 still earns +3 — same as the pre-Counter flat bonus.
+        state = self._state_with_explored(["src/foo.py"])
+        file_languages = {"src/foo.py": "python", "src/bar.py": "python"}
+
+        score_off, _ = _candidate_signal_score(
+            state, "src/bar.py", file_languages, known_targets=Counter()
+        )
+        score_on, reasons_on = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 1}),
+        )
+
+        assert "known import target from 1 explored file(s)" in reasons_on
+        assert score_on - score_off == 3
+
+    def test_known_import_target_scales_with_in_degree(self):
+        state = self._state_with_explored(["src/foo.py"])
+        file_languages = {"src/foo.py": "python", "src/bar.py": "python"}
+
+        score_1, _ = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 1}),
+        )
+        score_2, _ = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 2}),
+        )
+        score_3, _ = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 3}),
+        )
+
+        # 1*3=3, 2*3=6, 3*3=9 → each step +3 below the cap.
+        assert score_2 - score_1 == 3
+        assert score_3 - score_2 == 3
+
+    def test_known_import_target_capped_at_nine(self):
+        state = self._state_with_explored(["src/foo.py"])
+        file_languages = {"src/foo.py": "python", "src/bar.py": "python"}
+
+        score_3, _ = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 3}),
+        )
+        score_10, reasons_10 = _candidate_signal_score(
+            state, "src/bar.py", file_languages,
+            known_targets=Counter({"src/bar.py": 10}),
+        )
+
+        # 3 importers → +9; 10 importers → capped at +9 (no further reward).
+        assert score_3 == score_10
+        # Reason string still reflects the true in-degree even though
+        # the score is capped — useful for debugging.
+        assert "known import target from 10 explored file(s)" in reasons_10
+
+    def test_unvisited_dir_outweighs_chain_candidate(self):
+        # Agent explored one file in src/services. Compare:
+        #   - chain candidate: another file in src/services, in known_targets
+        #   - breadth candidate: a file in src/utils, NOT in known_targets
+        # Breadth must outscore chain so the agent actually moves.
+        file_languages = {
+            "src/services/auth.py":   "python",
+            "src/services/helper.py": "python",  # chain candidate
+            "src/utils/format.py":    "python",  # breadth candidate
+        }
+        state = self._state_with_explored(["src/services/auth.py"])
+
+        chain_score, chain_reasons = _candidate_signal_score(
+            state, "src/services/helper.py", file_languages,
+            known_targets=Counter({"src/services/helper.py": 1}),
+        )
+        breadth_score, breadth_reasons = _candidate_signal_score(
+            state, "src/utils/format.py", file_languages,
+            known_targets=Counter(),
+        )
+
+        assert breadth_score > chain_score, (
+            f"breadth ({breadth_score}: {breadth_reasons}) "
+            f"should outscore chain ({chain_score}: {chain_reasons})"
+        )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,6 +103,7 @@ export default function App() {
         snapshot.analysis_state,
         DEPTH_OPTIONS[depthIdx].steps,
         (evt) => setLiveFile(`${evt.file} · ${evt.explored} files · ${(evt.confidence * 100).toFixed(0)}%`),
+        true,  // force_refresh: manual Analyze always bypasses the cache
       );
       setLiveFile(null);
       const finalState: AnalysisState = loopResult.final_state;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -113,11 +113,16 @@ export async function runLoopStream(
   state: AnalysisState,
   maxSteps: number,
   onProgress: (event: ProgressEvent) => void,
+  forceRefresh: boolean = false,
 ): Promise<LoopResponse> {
   const res = await fetch(`${BASE}/snapshot/run/stream`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ analysis_state: state, max_steps: maxSteps }),
+    body: JSON.stringify({
+      analysis_state: state,
+      max_steps: maxSteps,
+      force_refresh: forceRefresh,
+    }),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));


### PR DESCRIPTION
Pushes the agent toward breadth-first coverage, fixes a silent extension-stripping bug in the known-import-target resolver, weights that bonus by in-degree, caps non-file-reading steps, and adds an explicit force_refresh option so the UI always reflects the current analyzer logic.

Breadth-first exploration pressure
- Rewrote RULE 3 to demand explicit directory switching every 2-3 files and name the layered folders (components, utils, hooks, services, api, types).
- Vite and general JS/TS prompt blocks now say "SPREAD OUT" instead of suggesting a linear main -> App chain.
- _build_system_message now surfaces "Visited directories" and "NOT YET VISITED (prioritize these)" lists computed from explored_files vs _cached_files, immediately before the RULES.
- _candidate_signal_score: new +4 "unvisited directory" signal on top of the existing +3 "new directory context" (+7 combined for a fresh directory).
- KNOWN_TOP_LEVEL_DIRS expanded with 17 common layered names (utils, hooks, services, api, types, components, datasources, lib, helpers, middleware, store, context, features, modules, controllers, repositories, domain).
- Known-import-target bonus weakened from +5 to a per-importer +3 so chain pull no longer outweighs breadth signals.
- _next_unexplored and _nudge_message now prefer candidates from unvisited directories, falling back to same-directory only when none are available.

Resolver correctness
- _resolved_import_targets now returns a Counter and delegates to the full _resolve_internal_import when given repo context, so relative JS/TS imports like './formFieldsSource' resolve to the real file 'datasources/formFieldsSource.ts' (with extension) instead of the extension-less string the naive resolver produced. Restores the known-import-target bonus and "explored_import_target" confidence credit that had been silently broken for every relative JS/TS import.
- All live call sites pass repo_path, package_roots, and scanned_files through (_refresh_candidates_for_signal, _tool_read_file, _nudge_message). Dead-code sites left on the naive fallback by design.

In-degree-weighted known-import-target bonus
- Bonus now scales with the number of explored files that import the target: +3 per importer, capped at +9. Reason string includes the in-degree for debuggability.

Non-file-reading step cap
- New total_non_file_steps counter alongside the existing consecutive_no_file_steps. When cumulative non-file steps reach max_steps // 3, the loop force-reads the next unexplored file. Prevents the agent from silently burning the budget on search_for_pattern, mark_architecture_insight, and nudge turns.
- Persisted to final_state for diagnostic visibility in the cache.

force_refresh option (cache bypass)
- New delete_state helper in analysis_state_store, idempotent on missing files.
- AnalysisLoopRequest gained force_refresh: bool = False.
- /repos/snapshot/run and /repos/snapshot/run/stream delete the cache for the repo_id before launching the loop when the flag is set.
- runLoopStream wrapper accepts forceRefresh, defaulting to false.
- App.tsx passes true on the Analyze button so every manual run reflects the current analyzer logic.

Tests
- +28 tests across the new behaviors: directory-aware exploration, unvisited-directory scoring, in-degree-weighted bonus and cap, delete_state and force_refresh, _resolved_import_targets with and without repo context, prompt guidance updates.
- Full suite: 109 passing.