### PR TITLE
Release v1.0.0: importable Python pipeline

### DIFF
--- a/codenarrator/__init__.py
+++ b/codenarrator/__init__.py
@@ -1,0 +1,21 @@
+"""
+codenarrator — autonomous codebase understanding pipeline.
+
+Public API:
+
+    from codenarrator import analyze
+
+    result = analyze("https://github.com/owner/repo", depth="standard")
+    result.show()                  # open the HTML report in a browser
+    result.to_json("graph.json")   # dump the dependency graph
+    print(result.explored_files)
+
+For now the package wraps the existing FastAPI backend's service layer
+in-process; it does not require a running server. The backend's
+``app.*`` modules are added to ``sys.path`` at import time.
+"""
+from codenarrator.pipeline import analyze
+from codenarrator.result import AnalysisResult
+
+__all__ = ["analyze", "AnalysisResult"]
+__version__ = "0.1.0"

--- a/codenarrator/pipeline.py
+++ b/codenarrator/pipeline.py
@@ -1,0 +1,157 @@
+"""
+End-to-end analysis pipeline.
+
+Wires the existing service layer (clone → snapshot → agentic loop → AI
+interpretation → HTML report) into a single in-process function call,
+bypassing FastAPI entirely.
+
+The signatures below mirror the underlying services *as they actually
+are*, not as the public ``analyze()`` API pretends. ``analyze()`` is
+the friendly facade.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Make the backend's ``app.*`` modules importable from this package without
+# requiring an installed-mode layout. This must happen before the first
+# ``from app...`` import below.
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+# Service-layer imports (after the sys.path insertion).
+from app.core.config import settings  # noqa: E402
+from app.services import agentic_analysis_service as _agentic_svc  # noqa: E402
+from app.services import ai_interpreter as _interpreter_svc  # noqa: E402
+from app.services.agentic_analysis_service import run_agentic_analysis_loop  # noqa: E402
+from app.services.ai_interpreter import interpret_architecture  # noqa: E402
+from app.services.analysis_snapshot_service import build_analysis_snapshot  # noqa: E402
+from app.services.git_service import clone_or_update_repo  # noqa: E402
+from app.services.report_generator import generate_html_report  # noqa: E402
+
+from codenarrator.result import AnalysisResult
+
+
+# Anchor data paths to the canonical backend/data/ tree so the CLI pipeline
+# writes clones, cache, and reports into the same places the FastAPI flow
+# does — both share the same backing store.
+# (There is no REPORTS_DIR setting; the pipeline writes reports by defaulting
+# analyze()'s output_dir to _BACKEND_ROOT / "data" / "reports".)
+settings.REPO_BASE_DIR = _BACKEND_ROOT / "data" / "repos"
+settings.ANALYSIS_CACHE_DIR = _BACKEND_ROOT / "data" / "analysis_cache"
+
+
+# Map the friendly depth name to a step budget. Matches the UI's DEPTH_OPTIONS.
+DEPTH_STEPS = {
+    "standard": 20,
+    "deep": 30,
+}
+
+
+def analyze(
+    repo_url: str,
+    depth: str = "standard",
+    llm: str = "ollama",
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    output_dir: Optional[str] = None,
+) -> AnalysisResult:
+    """
+    Clone a repository, run the full analysis pipeline in-process, and
+    return an ``AnalysisResult`` containing the dependency graph, AI
+    interpretation, and rendered HTML report.
+
+    Parameters
+    ----------
+    repo_url:
+        Any URL accepted by ``clone_or_update_repo`` (GitHub, GitLab,
+        Bitbucket HTTPS or SSH).
+    depth:
+        ``"standard"`` (20 steps) or ``"deep"`` (30 steps).
+    llm:
+        Provider tag, stored on the result for future pluggable
+        backends. Currently only ``"ollama"`` is wired.
+    model:
+        Override for ``settings.OLLAMA_MODEL`` (e.g. ``"llama3.1:8b"``).
+        The override is applied for the duration of this call and
+        restored on exit, even if the pipeline raises.
+    api_key:
+        Personal access token forwarded to ``clone_or_update_repo`` as
+        ``git_token`` for private repo cloning.
+    output_dir:
+        Where to write the HTML report. Defaults to a fresh temp dir.
+
+    Returns
+    -------
+    AnalysisResult
+    """
+    if depth not in DEPTH_STEPS:
+        raise ValueError(
+            f"depth must be one of {sorted(DEPTH_STEPS)}, got {depth!r}"
+        )
+    max_steps = DEPTH_STEPS[depth]
+
+    # Step 1 — clone (or update if already present).
+    local_path = clone_or_update_repo(
+        repo_url=repo_url,
+        force_clean=False,
+        git_token=api_key,
+    )
+
+    # The service modules captured ``settings.OLLAMA_MODEL`` at import time
+    # into their own module-level ``OLLAMA_MODEL`` constants — so to honour
+    # ``model=...`` we have to patch the modules directly, not just settings.
+    _orig_settings_model = settings.OLLAMA_MODEL
+    _orig_agentic_model = _agentic_svc.OLLAMA_MODEL
+    _orig_interpreter_model = _interpreter_svc.OLLAMA_MODEL
+
+    if model:
+        settings.OLLAMA_MODEL = model
+        _agentic_svc.OLLAMA_MODEL = model
+        _interpreter_svc.OLLAMA_MODEL = model
+
+    try:
+        # Step 2 — deterministic snapshot.
+        snapshot = build_analysis_snapshot(local_path)
+        initial_state = snapshot["analysis_state"]
+
+        # Step 3 — agentic exploration loop.
+        loop_out = run_agentic_analysis_loop(initial_state, max_steps=max_steps)
+        final_state = loop_out["final_state"]
+
+        # Step 4 — AI interpretation (always returns a dict; deterministic
+        # fallback for key_dependencies fires inside on Ollama failure).
+        interpretation = interpret_architecture(final_state)
+
+        # Step 5 — render report. Default to the canonical backend/data/reports
+        # directory so output lands alongside the FastAPI flow's reports.
+        if output_dir:
+            out_dir = Path(output_dir).expanduser().resolve()
+        else:
+            out_dir = _BACKEND_ROOT / "data" / "reports"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        report_path = out_dir / f"{_slug(Path(local_path).name)}-report.html"
+        report_path = generate_html_report(final_state, interpretation, report_path)
+        report_html = report_path.read_text(encoding="utf-8")
+    finally:
+        settings.OLLAMA_MODEL = _orig_settings_model
+        _agentic_svc.OLLAMA_MODEL = _orig_agentic_model
+        _interpreter_svc.OLLAMA_MODEL = _orig_interpreter_model
+
+    return AnalysisResult(
+        state=final_state,
+        interpretation=interpretation,
+        report_html=report_html,
+        report_path=str(report_path),
+        llm=llm,
+    )
+
+
+def _slug(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-.")
+    return cleaned or "report"

--- a/codenarrator/result.py
+++ b/codenarrator/result.py
@@ -1,0 +1,72 @@
+"""
+AnalysisResult — the value object returned by ``analyze()``.
+
+Bundles the final state, AI interpretation, and rendered HTML so the
+caller can render it inline, dump JSON, or pull individual fields.
+"""
+from __future__ import annotations
+
+import json
+import webbrowser
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class AnalysisResult:
+    """All artifacts produced by a single ``analyze()`` invocation."""
+
+    def __init__(
+        self,
+        state: Dict[str, Any],
+        interpretation: Optional[Dict[str, Any]],
+        report_html: str,
+        report_path: str,
+        llm: str = "ollama",
+    ):
+        self.state = state
+        self.interpretation = interpretation
+        self.report_html = report_html
+        self.report_path = report_path
+        self.llm = llm
+
+    # ---- side-effect actions -------------------------------------------------
+
+    def show(self) -> None:
+        """Open the rendered HTML report in the system's default browser."""
+        webbrowser.open(f"file://{self.report_path}")
+
+    def to_html(self, path: str) -> None:
+        """Write the rendered HTML to ``path``."""
+        Path(path).write_text(self.report_html, encoding="utf-8")
+
+    def to_json(self, path: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Return a JSON-serializable snapshot of the core analysis artifacts.
+        If ``path`` is given, also write the JSON to that path.
+        """
+        graph = self.state.get("dependency_graph_summary", {})
+        data = {
+            "internal_edges": graph.get("internal_edges", []),
+            "explored_files": self.state.get("explored_files", []),
+            "file_count": self.state.get("current_summary", {}).get("file_count", 0),
+        }
+        if path:
+            Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return data
+
+    # ---- convenience accessors -----------------------------------------------
+
+    @property
+    def dependency_graph(self) -> List[Dict[str, str]]:
+        """Resolved internal file-to-file edges (``[{"from": ..., "to": ...}, ...]``)."""
+        return self.state.get("dependency_graph_summary", {}).get("internal_edges", [])
+
+    @property
+    def explored_files(self) -> List[str]:
+        """Paths of every file the agent opened during exploration."""
+        return self.state.get("explored_files", [])
+
+    @property
+    def architecture_summary(self) -> Optional[Dict[str, Any]]:
+        """The AI interpretation dict (``architecture_pattern``, ``main_components``, ...)."""
+        return self.interpretation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codenarrator"
+version = "0.1.0"
+description = "Autonomous codebase understanding agent — clone a repo, get an architecture report."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "sharwariakre" }]
+license = { text = "MIT" }
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "pydantic",
+    "pydantic-settings",
+    "gitpython",
+    "ollama",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["codenarrator*"]
+exclude = ["backend*", "frontend*", "tests*"]


### PR DESCRIPTION
Adds a `codenarrator` Python package that wires the existing service layer into an in-process `analyze()` function — no FastAPI server needed. Verified end-to-end against two real repos with the local qwen2.5-coder:7b model (Journey-Builder/standard ~4 min; Dead-Serious/deep ~6.5 min).

- codenarrator/pipeline.py: clone -> snapshot -> agentic loop ->
  interpret -> render report. Anchors REPO_BASE_DIR and
  ANALYSIS_CACHE_DIR to backend/data/ so the CLI shares storage
  with the web app. Handles model override via module-level
  monkey-patch + finally restore. Passes api_key through as
  git_token for private repos.
- codenarrator/result.py: AnalysisResult with show(), to_html(), to_json(), and convenience accessors for dependency_graph, explored_files, architecture_summary.
- codenarrator/__init__.py: re-exports analyze + AnalysisResult.
- pyproject.toml: project metadata and dependency list so the package can be installed/distributed.